### PR TITLE
fix: coverage report artifact

### DIFF
--- a/.github/actions/ci-env/action.yml
+++ b/.github/actions/ci-env/action.yml
@@ -22,3 +22,4 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
       shell: bash
+    

--- a/.github/actions/ci-env/action.yml
+++ b/.github/actions/ci-env/action.yml
@@ -22,4 +22,3 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
       shell: bash
-    

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Run Jest
         run: npm run test
 
+      - name: Upload test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ./coverage/lcov-report
+          retention-days: 30          
+          if-no-files-found: error # this should never fail!
+
   eslint:
     name: ESLint (linting)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           name: coverage
           path: ./coverage/lcov-report
-          retention-days: 30          
+          retention-days: 30
           if-no-files-found: error # this should never fail!
 
   eslint:


### PR DESCRIPTION
Code coverage reports now get uploaded as artifacts by the CI workflow