### PR TITLE
feat: Added context wrapper for mocking Prisma Client

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from "@prisma/client";
+import { enhance } from "@zenstackhq/runtime";
+
+import { mockDeep, DeepMockProxy } from "jest-mock-extended";
+
+export type Context = {
+  prisma: PrismaClient;
+  prismaEnhanced: PrismaClient;
+};
+
+export type MockContext = {
+  prisma: DeepMockProxy<PrismaClient>;
+  prismaEnhanced: DeepMockProxy<PrismaClient>;
+};
+
+export function createMockContext(userId?: string): [Context, MockContext] {
+  const prisma = mockDeep<PrismaClient>();
+  const prismaEnhanced =
+    userId === undefined ? prisma : enhance(prisma, { user: { id: userId } });
+
+  const context = { prisma, prismaEnhanced };
+  return [context, context];
+}


### PR DESCRIPTION
Prisma Client can now be mocked using the Context wrapper and dependency injection.
